### PR TITLE
Ensure MongoDB persistence and drop local state modules

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -80,6 +80,7 @@ const App: React.FC = () => {
   const [shotCovers, setShotCovers] = useState<ShotCovers>({});
   const [activePlaylistId, setActivePlaylistId] = useState<string | null>(null);
   const [isSidebarOpen, setIsSidebarOpen] = useState<boolean>(true);
+  const [isLoaded, setIsLoaded] = useState(false);
 
   const [searchQuery, setSearchQuery] = useState('');
   const [selectedTags, setSelectedTags] = useState<Set<string>>(new Set());
@@ -130,12 +131,15 @@ const App: React.FC = () => {
         }
       } catch (err) {
         console.error('Failed to load state:', err);
+      } finally {
+        setIsLoaded(true);
       }
     };
     load();
   }, []);
 
   useEffect(() => {
+    if (!isLoaded) return;
     const save = async () => {
       try {
         await fetch(`${API_BASE_URL}/api/playlists`, {
@@ -148,9 +152,10 @@ const App: React.FC = () => {
       }
     };
     save();
-  }, [playlists]);
+  }, [playlists, isLoaded]);
 
   useEffect(() => {
+    if (!isLoaded) return;
     const save = async () => {
       try {
         await fetch(`${API_BASE_URL}/api/tags`, {
@@ -163,9 +168,10 @@ const App: React.FC = () => {
       }
     };
     save();
-  }, [tags, allGlobalTags]);
+  }, [tags, allGlobalTags, isLoaded]);
 
   useEffect(() => {
+    if (!isLoaded) return;
     const save = async () => {
       try {
         await fetch(`${API_BASE_URL}/api/settings`, {
@@ -178,7 +184,7 @@ const App: React.FC = () => {
       }
     };
     save();
-  }, [shotCovers, activePlaylistId, isSidebarOpen]);
+  }, [shotCovers, activePlaylistId, isSidebarOpen, isLoaded]);
   
   useEffect(() => {
     if (renamingPlaylist && renameInputRef.current) {

--- a/components/UserContext.tsx
+++ b/components/UserContext.tsx
@@ -30,6 +30,7 @@ const UserContext = createContext<UserContextType | undefined>(undefined);
 export const UserProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
   const [users, setUsers] = useState<User[]>(initialUsers);
   const [currentUser, setCurrentUser] = useState<User>(initialUsers[0]);
+  const [isLoaded, setIsLoaded] = useState(false);
 
   useEffect(() => {
     const load = async () => {
@@ -44,12 +45,15 @@ export const UserProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
         }
       } catch (err) {
         console.error('Failed to load user state:', err);
+      } finally {
+        setIsLoaded(true);
       }
     };
     load();
   }, []);
 
   useEffect(() => {
+    if (!isLoaded) return;
     const save = async () => {
       try {
         await fetch(`${API_BASE_URL}/api/users`, {
@@ -66,7 +70,7 @@ export const UserProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
     if (!users.find(u => u.email === currentUser.email)) {
       setCurrentUser(users[0] || initialUsers[0]);
     }
-  }, [users, currentUser.email]);
+  }, [users, currentUser.email, isLoaded]);
 
   const handleSetCurrentUser = (user: User) => {
     setCurrentUser(user);


### PR DESCRIPTION
## Summary
- prevent initial empty state from overwriting MongoDB by deferring playlist, tag, and settings saves until after load
- delay user save operations until user data is fetched from the server
- remove obsolete local db stub

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6891a4f9bd408326916298d07315cdb6