### PR TITLE
Persist directories via MongoDB

### DIFF
--- a/components/SettingsModal.tsx
+++ b/components/SettingsModal.tsx
@@ -129,9 +129,9 @@ const SourceFoldersTab: React.FC<{
                     />
                 </div>
             </div>
-             <div className="p-4 bg-yellow-900/30 rounded-lg">
-                <p className="text-yellow-300 text-sm">
-                    <strong>توجه:</strong> به دلیل محدودیت‌های محیط اجرا، لیست پوشه‌های مبدا به صورت دائمی ذخیره نمی‌شود و با هر بار بستن و باز کردن برنامه باید مجددا انتخاب شوند.
+             <div className="p-4 bg-green-900/30 rounded-lg">
+                <p className="text-green-300 text-sm">
+                    پوشه‌های مبدا در پایگاه داده ذخیره می‌شوند و پس از باز کردن دوباره برنامه نیز در دسترس هستند.
                 </p>
             </div>
         </div>

--- a/server.js
+++ b/server.js
@@ -37,6 +37,10 @@ const globalTagSchema = new mongoose.Schema({
   tags: [String]
 });
 
+const directorySchema = new mongoose.Schema({
+  _id: String
+});
+
 const appSettingsSchema = new mongoose.Schema({
   _id: { type: String, default: 'singleton' },
   shotCovers: mongoose.Schema.Types.Mixed,
@@ -50,6 +54,7 @@ const Playlist = mongoose.model('Playlist', playlistSchema);
 const Tag = mongoose.model('Tag', tagSchema);
 const GlobalTag = mongoose.model('GlobalTag', globalTagSchema);
 const AppSettings = mongoose.model('AppSettings', appSettingsSchema);
+const Directory = mongoose.model('Directory', directorySchema);
 
 const app = express();
 app.use(cors());
@@ -108,6 +113,19 @@ app.post('/api/tags', async (req, res) => {
   const docs = Object.entries(tags || {}).map(([shotId, tagArr]) => ({ _id: shotId, tags: tagArr }));
   if (docs.length) await Tag.insertMany(docs);
   await GlobalTag.findByIdAndUpdate('singleton', { tags: allGlobalTags || [] }, { upsert: true });
+  res.json({ status: 'ok' });
+});
+
+app.get('/api/directories', async (_req, res) => {
+  const docs = await Directory.find({}).lean();
+  res.json({ directories: docs.map(d => d._id) });
+});
+
+app.post('/api/directories', async (req, res) => {
+  const { directories } = req.body;
+  await Directory.deleteMany({});
+  const docs = (directories || []).map((name) => ({ _id: name }));
+  if (docs.length) await Directory.insertMany(docs);
   res.json({ status: 'ok' });
 });
 


### PR DESCRIPTION
## Summary
- Add MongoDB Directory model and API endpoints to save and retrieve folder names
- Sync `sourceFolders` state with new endpoints, including in backups
- Update settings modal text to reflect database persistence

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6891b67377a0832693acd29af2caa1e1