### PR TITLE
Add Docker configuration for running app

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+# Use official Node.js runtime as a parent image
+FROM node:20-alpine
+
+# Set working directory
+WORKDIR /app
+
+# Install dependencies
+COPY package*.json ./
+RUN npm install
+
+# Copy the rest of the application code
+COPY . .
+
+# Expose ports for the API and Vite dev server
+EXPOSE 3000 5173
+
+# Default command (can be overridden in docker-compose for the client)
+CMD ["npm", "run", "server"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,26 @@
+version: '3.8'
+services:
+  server:
+    build: .
+    command: npm run server
+    ports:
+      - "3000:3000"
+    environment:
+      MONGODB_URI: mongodb://mongo:27017/j9
+    depends_on:
+      - mongo
+  client:
+    build: .
+    command: npm run dev -- --host 0.0.0.0
+    ports:
+      - "5173:5173"
+    depends_on:
+      - server
+  mongo:
+    image: mongo:6
+    ports:
+      - "27017:27017"
+    volumes:
+      - mongo-data:/data/db
+volumes:
+  mongo-data:

--- a/server.js
+++ b/server.js
@@ -2,8 +2,9 @@ import express from 'express';
 import mongoose from 'mongoose';
 import cors from 'cors';
 
-const MONGODB_URI = 'mongodb://127.0.0.1:27017/j9';
-//const MONGODB_URI = process.env.MONGODB_URI || 'mongodb://localhost:27017/j9';
+// Allow the MongoDB connection string to be configured via environment
+// variables when running in different environments (e.g. Docker).
+const MONGODB_URI = process.env.MONGODB_URI || 'mongodb://127.0.0.1:27017/j9';
 
 mongoose.connect(MONGODB_URI)
   .then(() => console.log('MongoDB connected'))


### PR DESCRIPTION
## Summary
- Allow MongoDB connection via `MONGODB_URI` environment variable
- Add Dockerfile for Node runtime
- Add docker-compose setup for server, client, and MongoDB

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6891dce4c7bc8326b6b5648665188835